### PR TITLE
Fix generate/create with options namespace.

### DIFF
--- a/src/Service/Database/ListTablesService.php
+++ b/src/Service/Database/ListTablesService.php
@@ -37,7 +37,7 @@ final class ListTablesService
         $migrationTable = $this->db->getSchema()->getRawTableName($this->migrationService->getMigrationTable());
         $dsn = $this->db->getDSN();
 
-        if ($dsn === null) {
+        if (empty($dsn)) {
             $this->consoleHelper->io()->error('Dsn cannot be empty.');
 
             return ExitCode::UNSPECIFIED_ERROR;

--- a/src/Service/MigrationService.php
+++ b/src/Service/MigrationService.php
@@ -495,7 +495,7 @@ final class MigrationService
      */
     public function generateClassName(?string $namespace, string $name): array
     {
-        if (empty($this->createPath)) {
+        if (empty($this->createPath) && empty($namespace)) {
             $namespace = $this->createNamespace;
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

Example:

```php
 ./yii generate/create item --namespace App\\Module\\Rbac\\Migration
```
