### PR TITLE
Fix response code when system is up-to-date

### DIFF
--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -80,7 +80,7 @@ final class UpdateCommand extends Command
             $this->consoleHelper->io()->success('Your system is up-to-date.');
             $this->migrationService->dbVersion();
 
-            return ExitCode::UNSPECIFIED_ERROR;
+            return ExitCode::OK;
         }
 
         $total = count($migrations);

--- a/tests/src/Command/Namespaces/UpdateCommandTest.php
+++ b/tests/src/Command/Namespaces/UpdateCommandTest.php
@@ -81,7 +81,7 @@ final class UpdateCommandTest extends NamespacesCommandTest
 
         $command->setInputs(['yes']);
 
-        $this->assertEquals(ExitCode::UNSPECIFIED_ERROR, $command->execute([]));
+        $this->assertEquals(ExitCode::OK, $command->execute([]));
 
         $output = $command->getDisplay(true);
 

--- a/tests/src/Command/Paths/UpdateCommandTest.php
+++ b/tests/src/Command/Paths/UpdateCommandTest.php
@@ -81,7 +81,7 @@ final class UpdateCommandTest extends PathsCommandTest
 
         $command->setInputs(['yes']);
 
-        $this->assertEquals(ExitCode::UNSPECIFIED_ERROR, $command->execute([]));
+        $this->assertEquals(ExitCode::OK, $command->execute([]));
 
         $output = $command->getDisplay(true);
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

When used in CI, it throws an error if system is up-to-date.