### PR TITLE
For command `migrate/down` added option `--all` and default value `1` for option `--limit`

### DIFF
--- a/src/Command/DownCommand.php
+++ b/src/Command/DownCommand.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace Yiisoft\Yii\Db\Migration\Command;
 
-use Yiisoft\Yii\Db\Migration\Informer\ConsoleMigrationInformer;
-use Yiisoft\Yii\Db\Migration\Migrator;
-use function array_keys;
-use function count;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -15,9 +11,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Yiisoft\Yii\Console\ExitCode;
 use Yiisoft\Yii\Db\Migration\Helper\ConsoleHelper;
-
+use Yiisoft\Yii\Db\Migration\Informer\ConsoleMigrationInformer;
+use Yiisoft\Yii\Db\Migration\Migrator;
 use Yiisoft\Yii\Db\Migration\Service\Migrate\DownService;
 use Yiisoft\Yii\Db\Migration\Service\MigrationService;
+
+use function array_keys;
+use function count;
 
 /**
  * Downgrades the application by reverting old migrations.
@@ -60,7 +60,7 @@ final class DownCommand extends Command
     {
         $this
             ->setDescription('Downgrades the application by reverting old migrations.')
-            ->addOption('limit', 'l', InputOption::VALUE_OPTIONAL, 'Number of migrations to downgrade.', null)
+            ->addOption('limit', 'l', InputOption::VALUE_OPTIONAL, 'Number of migrations to downgrade.', 1)
             ->setHelp('This command downgrades the application by reverting old migrations.');
     }
 
@@ -71,9 +71,9 @@ final class DownCommand extends Command
     {
         $this->migrationService->before(self::$defaultName);
 
-        $limit = filter_var($input->getOption('limit'), FILTER_VALIDATE_INT, FILTER_NULL_ON_FAILURE);
+        $limit = (int)$input->getOption('limit');
 
-        if ($limit < 0) {
+        if ($limit <= 0) {
             $this->consoleHelper->io()->error('The step argument must be greater than 0.');
             $this->migrationService->dbVersion();
 

--- a/src/Command/DownCommand.php
+++ b/src/Command/DownCommand.php
@@ -61,6 +61,7 @@ final class DownCommand extends Command
         $this
             ->setDescription('Downgrades the application by reverting old migrations.')
             ->addOption('limit', 'l', InputOption::VALUE_OPTIONAL, 'Number of migrations to downgrade.', 1)
+            ->addOption('all', 'a', InputOption::VALUE_NONE, 'Downgrade all migrations.')
             ->setHelp('This command downgrades the application by reverting old migrations.');
     }
 
@@ -71,13 +72,14 @@ final class DownCommand extends Command
     {
         $this->migrationService->before(self::$defaultName);
 
-        $limit = (int)$input->getOption('limit');
-
-        if ($limit <= 0) {
-            $this->consoleHelper->io()->error('The step argument must be greater than 0.');
-            $this->migrationService->dbVersion();
-
-            return ExitCode::DATAERR;
+        $limit = null;
+        if (!$input->getOption('all')) {
+            $limit = (int)$input->getOption('limit');
+            if ($limit <= 0) {
+                $this->consoleHelper->io()->error('The step argument must be greater than 0.');
+                $this->migrationService->dbVersion();
+                return ExitCode::DATAERR;
+            }
         }
 
         $migrations = $this->migrator->getHistory($limit);

--- a/src/Command/DownCommand.php
+++ b/src/Command/DownCommand.php
@@ -76,7 +76,7 @@ final class DownCommand extends Command
         if (!$input->getOption('all')) {
             $limit = (int)$input->getOption('limit');
             if ($limit <= 0) {
-                $this->consoleHelper->io()->error('The step argument must be greater than 0.');
+                $this->consoleHelper->io()->error('The limit argument must be greater than 0.');
                 $this->migrationService->dbVersion();
                 return ExitCode::DATAERR;
             }

--- a/tests/src/Command/Namespaces/DownCommandTest.php
+++ b/tests/src/Command/Namespaces/DownCommandTest.php
@@ -25,9 +25,10 @@ final class DownCommandTest extends NamespacesCommandTest
 
         $output = $command->getDisplay(true);
 
-        $this->assertStringContainsString('2 migrations were reverted.', $output);
+        $this->assertStringContainsString(' 1 migration was reverted.', $output);
 
-        $this->assertNotExistsTables('post', 'user');
+        $this->assertNotExistsTables('user');
+        $this->assertExistsTables('post');
     }
 
     public function testExecuteAgain(): void
@@ -41,28 +42,40 @@ final class DownCommandTest extends NamespacesCommandTest
         $this->assertStringContainsString('Apply a new migration to run this command.', $output);
     }
 
+    public function dataIncorrectLimit(): array
+    {
+        return [
+            'negative' => [-1],
+            'zero' => [0],
+        ];
+    }
+
+    /**
+     * @dataProvider dataIncorrectLimit
+     */
+    public function testIncorrectLimit(int $limit): void
+    {
+        $command = $this->getCommand();
+
+        $exitCode = $command->execute(['-l' => $limit]);
+
+        $this->assertSame(ExitCode::DATAERR, $exitCode);
+    }
+
     public function testLimit(): void
     {
         $this->createMigration('Create_Post', 'table', 'post', ['name:string']);
         $this->createMigration('Create_User', 'table', 'user', ['name:string']);
+        $this->createMigration('Create_Tag', 'table', 'tag', ['name:string']);
         $this->applyNewMigrations();
 
         $command = $this->getCommand();
 
-        $exitCode = $command->execute(['-l' => '1']);
+        $exitCode = $command->execute(['-l' => '2']);
         $output = $command->getDisplay(true);
 
         $this->assertSame(ExitCode::OK, $exitCode);
-        $this->assertStringContainsString('[OK] 1 migration was reverted.', $output);
-    }
-
-    public function testIncorrectLimit(): void
-    {
-        $command = $this->getCommand();
-
-        $exitCode = $command->execute(['-l' => -1]);
-
-        $this->assertSame(ExitCode::DATAERR, $exitCode);
+        $this->assertStringContainsString('[OK] 2 migrations were reverted.', $output);
     }
 
     public function testFiled(): void

--- a/tests/src/Command/Namespaces/DownCommandTest.php
+++ b/tests/src/Command/Namespaces/DownCommandTest.php
@@ -25,7 +25,7 @@ final class DownCommandTest extends NamespacesCommandTest
 
         $output = $command->getDisplay(true);
 
-        $this->assertStringContainsString(' 1 migration was reverted.', $output);
+        $this->assertStringContainsString('1 migration was reverted.', $output);
 
         $this->assertNotExistsTables('user');
         $this->assertExistsTables('post');
@@ -57,7 +57,7 @@ final class DownCommandTest extends NamespacesCommandTest
 
         $output = $command->getDisplay(true);
 
-        $this->assertStringContainsString(' 2 migrations were reverted.', $output);
+        $this->assertStringContainsString('2 migrations were reverted.', $output);
 
         $this->assertNotExistsTables('post', 'user');
     }

--- a/tests/src/Command/Namespaces/DownCommandTest.php
+++ b/tests/src/Command/Namespaces/DownCommandTest.php
@@ -42,6 +42,26 @@ final class DownCommandTest extends NamespacesCommandTest
         $this->assertStringContainsString('Apply a new migration to run this command.', $output);
     }
 
+    public function testDowngradeAll(): void
+    {
+        $this->createMigration('Create_Post', 'table', 'post', ['name:string']);
+        $this->createMigration('Create_User', 'table', 'user', ['name:string']);
+        $this->applyNewMigrations();
+
+        $this->assertExistsTables('post', 'user');
+
+        $command = $this->getCommand();
+        $command->setInputs(['yes']);
+
+        $this->assertEquals(ExitCode::OK, $command->execute(['--all' => true]));
+
+        $output = $command->getDisplay(true);
+
+        $this->assertStringContainsString(' 2 migrations were reverted.', $output);
+
+        $this->assertNotExistsTables('post', 'user');
+    }
+
     public function dataIncorrectLimit(): array
     {
         return [

--- a/tests/src/Command/Paths/DownCommandTest.php
+++ b/tests/src/Command/Paths/DownCommandTest.php
@@ -25,7 +25,7 @@ final class DownCommandTest extends PathsCommandTest
 
         $output = $command->getDisplay(true);
 
-        $this->assertStringContainsString(' 1 migration was reverted.', $output);
+        $this->assertStringContainsString('1 migration was reverted.', $output);
 
         $this->assertNotExistsTables('user');
         $this->assertExistsTables('post');
@@ -57,7 +57,7 @@ final class DownCommandTest extends PathsCommandTest
 
         $output = $command->getDisplay(true);
 
-        $this->assertStringContainsString(' 2 migrations were reverted.', $output);
+        $this->assertStringContainsString('2 migrations were reverted.', $output);
 
         $this->assertNotExistsTables('post', 'user');
     }

--- a/tests/src/Command/Paths/DownCommandTest.php
+++ b/tests/src/Command/Paths/DownCommandTest.php
@@ -42,6 +42,26 @@ final class DownCommandTest extends PathsCommandTest
         $this->assertStringContainsString('Apply a new migration to run this command.', $output);
     }
 
+    public function testDowngradeAll(): void
+    {
+        $this->createMigration('Create_Post', 'table', 'post', ['name:string']);
+        $this->createMigration('Create_User', 'table', 'user', ['name:string']);
+        $this->applyNewMigrations();
+
+        $this->assertExistsTables('post', 'user');
+
+        $command = $this->getCommand();
+        $command->setInputs(['yes']);
+
+        $this->assertEquals(ExitCode::OK, $command->execute(['--all' => true]));
+
+        $output = $command->getDisplay(true);
+
+        $this->assertStringContainsString(' 2 migrations were reverted.', $output);
+
+        $this->assertNotExistsTables('post', 'user');
+    }
+
     public function dataIncorrectLimit(): array
     {
         return [

--- a/tests/src/Command/Paths/DownCommandTest.php
+++ b/tests/src/Command/Paths/DownCommandTest.php
@@ -25,9 +25,10 @@ final class DownCommandTest extends PathsCommandTest
 
         $output = $command->getDisplay(true);
 
-        $this->assertStringContainsString('2 migrations were reverted.', $output);
+        $this->assertStringContainsString(' 1 migration was reverted.', $output);
 
-        $this->assertNotExistsTables('post', 'user');
+        $this->assertNotExistsTables('user');
+        $this->assertExistsTables('post');
     }
 
     public function testExecuteAgain(): void
@@ -41,28 +42,40 @@ final class DownCommandTest extends PathsCommandTest
         $this->assertStringContainsString('Apply a new migration to run this command.', $output);
     }
 
+    public function dataIncorrectLimit(): array
+    {
+        return [
+            'negative' => [-1],
+            'zero' => [0],
+        ];
+    }
+
+    /**
+     * @dataProvider dataIncorrectLimit
+     */
+    public function testIncorrectLimit(int $limit): void
+    {
+        $command = $this->getCommand();
+
+        $exitCode = $command->execute(['-l' => $limit]);
+
+        $this->assertSame(ExitCode::DATAERR, $exitCode);
+    }
+
     public function testLimit(): void
     {
         $this->createMigration('Create_Post', 'table', 'post', ['name:string']);
         $this->createMigration('Create_User', 'table', 'user', ['name:string']);
+        $this->createMigration('Create_Tag', 'table', 'tag', ['name:string']);
         $this->applyNewMigrations();
 
         $command = $this->getCommand();
 
-        $exitCode = $command->execute(['-l' => '1']);
+        $exitCode = $command->execute(['-l' => '2']);
         $output = $command->getDisplay(true);
 
         $this->assertSame(ExitCode::OK, $exitCode);
-        $this->assertStringContainsString('[OK] 1 migration was reverted.', $output);
-    }
-
-    public function testIncorrectLimit(): void
-    {
-        $command = $this->getCommand();
-
-        $exitCode = $command->execute(['-l' => -1]);
-
-        $this->assertSame(ExitCode::DATAERR, $exitCode);
+        $this->assertStringContainsString('[OK] 2 migrations were reverted.', $output);
     }
 
     public function testFiled(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Fixed issues  | #106 
