### PR TITLE
`MigrationService::findMigrationPath()` returns path with translated path aliases

### DIFF
--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -11,7 +11,6 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
-use Yiisoft\Aliases\Aliases;
 use Yiisoft\Files\FileHelper;
 use Yiisoft\Strings\Inflector;
 use Yiisoft\Yii\Console\ExitCode;
@@ -86,7 +85,6 @@ use function strlen;
  */
 final class CreateCommand extends Command
 {
-    private Aliases $aliases;
     private CreateService $createService;
     private MigrationService $migrationService;
 
@@ -95,12 +93,10 @@ final class CreateCommand extends Command
     private Migrator $migrator;
 
     public function __construct(
-        Aliases $aliases,
         CreateService $createService,
         MigrationService $migrationService,
         Migrator $migrator
     ) {
-        $this->aliases = $aliases;
         $this->createService = $createService;
         $this->migrationService = $migrationService;
         $this->migrator = $migrator;
@@ -182,9 +178,7 @@ final class CreateCommand extends Command
             return ExitCode::DATAERR;
         }
 
-        $migrationPath = $this->aliases->get(
-            FileHelper::normalizePath($this->migrationService->findMigrationPath($namespace))
-        );
+        $migrationPath = FileHelper::normalizePath($this->migrationService->findMigrationPath($namespace));
 
         $file = $migrationPath . DIRECTORY_SEPARATOR . $className . '.php';
 

--- a/src/Service/MigrationService.php
+++ b/src/Service/MigrationService.php
@@ -326,19 +326,17 @@ final class MigrationService
     /**
      * Finds the file path for the specified migration namespace.
      *
-     * @param string|null $namespace migration namespace.
+     * @param string|null $namespace The migration namespace.
      *
-     * @return string migration file path.
+     * @return string The migration file path.
      */
     public function findMigrationPath(?string $namespace): string
     {
         $namespace = $namespace ?? $this->createNamespace;
 
-        if (empty($namespace)) {
-            return $this->createPath;
-        }
-
-        return $this->getNamespacePath($namespace);
+        return empty($namespace)
+            ? $this->aliases->get($this->createPath)
+            : $this->getNamespacePath($namespace);
     }
 
     /**

--- a/tests/src/Support/Helper/ContainerHelper.php
+++ b/tests/src/Support/Helper/ContainerHelper.php
@@ -90,7 +90,6 @@ final class ContainerHelper
 
             case CreateCommand::class:
                 return new CreateCommand(
-                    $container->get(Aliases::class),
                     $container->get(CreateService::class),
                     $container->get(MigrationService::class),
                     $container->get(Migrator::class),


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -