### PR TITLE
Remove Usage of Recently Removed yiisoft/db Classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "yiisoft/db-pgsql": "^3.0@dev",
         "yiisoft/db-sqlite": "^3.0@dev",
         "yiisoft/di": "^1.0",
+        "yiisoft/profiler": "^2.0",
         "yiisoft/test-support": "^3.0"
     },
     "autoload": {

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -6,7 +6,6 @@ namespace Yiisoft\Yii\Db\Migration;
 
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Yiisoft\Arrays\ArrayHelper;
-use Yiisoft\Db\Cache\QueryCache;
 use Yiisoft\Db\Cache\SchemaCache;
 use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Query\Query;
@@ -19,7 +18,6 @@ final class Migrator
 {
     private ConnectionInterface $db;
     private SchemaCache $schemaCache;
-    private QueryCache $queryCache;
     private MigrationInformerInterface $informer;
 
     private string $historyTable;
@@ -27,19 +25,16 @@ final class Migrator
 
     private bool $checkMigrationHistoryTable = true;
     private bool $schemaCacheEnabled = false;
-    private bool $queryCacheEnabled = false;
 
     public function __construct(
         ConnectionInterface $db,
         SchemaCache $schemaCache,
-        QueryCache $queryCache,
         MigrationInformerInterface $informer,
         string $historyTable = '{{%migration}}',
         ?int $maxMigrationNameLength = 180
     ) {
         $this->db = $db;
         $this->schemaCache = $schemaCache;
-        $this->queryCache = $queryCache;
         $this->informer = $informer;
 
         $this->historyTable = $historyTable;
@@ -179,11 +174,6 @@ final class Migrator
 
     private function beforeMigrate(): void
     {
-        $this->queryCacheEnabled = $this->queryCache->isEnabled();
-        if ($this->queryCacheEnabled) {
-            $this->queryCache->setEnable(false);
-        }
-
         $this->schemaCacheEnabled = $this->schemaCache->isEnabled();
         if ($this->schemaCacheEnabled) {
             $this->schemaCache->setEnable(false);
@@ -192,10 +182,6 @@ final class Migrator
 
     private function afterMigrate(): void
     {
-        if ($this->queryCacheEnabled) {
-            $this->queryCache->setEnable(true);
-        }
-
         if ($this->schemaCacheEnabled) {
             $this->schemaCache->setEnable(true);
         }

--- a/tests/src/MigratorTest.php
+++ b/tests/src/MigratorTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yiisoft\Yii\Db\Migration\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Yiisoft\Db\Cache\QueryCache;
 use Yiisoft\Db\Cache\SchemaCache;
 use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Yii\Db\Migration\Informer\NullMigrationInformer;
@@ -24,7 +23,6 @@ final class MigratorTest extends TestCase
         $migrator = new Migrator(
             $container->get(ConnectionInterface::class),
             $container->get(SchemaCache::class),
-            $container->get(QueryCache::class),
             new NullMigrationInformer(),
             '{{%migration}}',
             42
@@ -41,7 +39,6 @@ final class MigratorTest extends TestCase
         $migrator = new Migrator(
             $container->get(ConnectionInterface::class),
             $container->get(SchemaCache::class),
-            $container->get(QueryCache::class),
             new NullMigrationInformer(),
             '{{%migration}}',
             null
@@ -60,7 +57,6 @@ final class MigratorTest extends TestCase
         $migrator = new Migrator(
             $db,
             $container->get(SchemaCache::class),
-            $container->get(QueryCache::class),
             new NullMigrationInformer(),
             '{{%migration}}',
             null
@@ -87,7 +83,6 @@ final class MigratorTest extends TestCase
         $migrator = new Migrator(
             $container->get(ConnectionInterface::class),
             $container->get(SchemaCache::class),
-            $container->get(QueryCache::class),
             new NullMigrationInformer(),
             '{{%migration}}',
             null

--- a/tests/src/Support/Helper/ContainerHelper.php
+++ b/tests/src/Support/Helper/ContainerHelper.php
@@ -7,7 +7,6 @@ namespace Yiisoft\Yii\Db\Migration\Tests\Support\Helper;
 use Psr\Container\ContainerInterface;
 use Yiisoft\Aliases\Aliases;
 use Yiisoft\Cache\CacheInterface;
-use Yiisoft\Db\Cache\QueryCache;
 use Yiisoft\Db\Cache\SchemaCache;
 use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Injector\Injector;
@@ -36,9 +35,6 @@ final class ContainerHelper
             case SchemaCache::class:
                 return new SchemaCache($container->get(CacheInterface::class));
 
-            case QueryCache::class:
-                return new QueryCache($container->get(CacheInterface::class));
-
             case Injector::class:
                 return new Injector($container);
 
@@ -56,7 +52,6 @@ final class ContainerHelper
                 return new Migrator(
                     $container->get(ConnectionInterface::class),
                     $container->get(SchemaCache::class),
-                    $container->get(QueryCache::class),
                     $container->get(ConsoleMigrationInformer::class),
                 );
 

--- a/tests/src/Support/Helper/PostgreSqlHelper.php
+++ b/tests/src/Support/Helper/PostgreSqlHelper.php
@@ -11,9 +11,7 @@ use Yiisoft\Aliases\Aliases;
 use Yiisoft\Cache\ArrayCache;
 use Yiisoft\Cache\Cache;
 use Yiisoft\Cache\CacheInterface;
-use Yiisoft\Db\Cache\QueryCache;
 use Yiisoft\Db\Cache\SchemaCache;
-use Yiisoft\Db\Connection\Connection;
 use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Pgsql\ConnectionPDO as PgSqlConnection;
 use Yiisoft\Db\Pgsql\PDODriver as PgSqlPDODriver;
@@ -47,7 +45,6 @@ final class PostgreSqlHelper
                                 'postgres',
                                 'postgres',
                             ),
-                            $container->get(QueryCache::class),
                             $container->get(SchemaCache::class),
                         );
 
@@ -75,7 +72,7 @@ final class PostgreSqlHelper
 
     public static function createSchema(ContainerInterface $container, string $name): void
     {
-        /** @var Connection $connection */
+        /** @var ConnectionInterface $connection */
         $connection = $container->get(ConnectionInterface::class);
 
         $quotedName = $connection->getQuoter()->quoteTableName($name);

--- a/tests/src/Support/Helper/SqLiteHelper.php
+++ b/tests/src/Support/Helper/SqLiteHelper.php
@@ -11,7 +11,6 @@ use Yiisoft\Aliases\Aliases;
 use Yiisoft\Cache\ArrayCache;
 use Yiisoft\Cache\Cache;
 use Yiisoft\Cache\CacheInterface;
-use Yiisoft\Db\Cache\QueryCache;
 use Yiisoft\Db\Cache\SchemaCache;
 use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Sqlite\ConnectionPDO as SqLiteConnection;
@@ -41,7 +40,6 @@ final class SqLiteHelper
                             new SqLitePDODriver(
                                 'sqlite:' . dirname(__DIR__, 3) . '/runtime/testdb.sq3'
                             ),
-                            $container->get(QueryCache::class),
                             $container->get(SchemaCache::class),
                         );
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | Removes uses of now non-existing classes `Yiisoft\Db\Cache\QueryCache` and `Yiisoft\Db\Connection\Connection`.
Also added the missing composer package `yiisoft/profiler`
