### PR TITLE
Use `newMigrationPath` and `newMigrationNamespace` if `sourceNamespaces` and `sourcePaths` are not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Enh #322, #330: Improve output of `migrate:up`, `migrate:down`, `migrate:redo`, `migrate:new`, `migrate:history`, and
   `migrate:create` commands: remove redundant messages, replace `>>>` with cleaner output, and move "Database
   connection" info to the top (@samdark, @vjik)
+- Enh #333: Use `newMigrationPath` and `newMigrationNamespace` if `sourceNamespaces` and `sourcePaths` are not specified (@Tigrov)
 
 ## 2.0.1 December 20, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Enh #322, #330: Improve output of `migrate:up`, `migrate:down`, `migrate:redo`, `migrate:new`, `migrate:history`, and
   `migrate:create` commands: remove redundant messages, replace `>>>` with cleaner output, and move "Database
   connection" info to the top (@samdark, @vjik)
-- Enh #333: Use `newMigrationPath` and `newMigrationNamespace` if `sourceNamespaces` and `sourcePaths` are not specified (@Tigrov)
+- Enh #333: Use `newMigrationPath` and `newMigrationNamespace` as source (@Tigrov)
 
 ## 2.0.1 December 20, 2025
 

--- a/composer.json
+++ b/composer.json
@@ -37,16 +37,16 @@
         "yiisoft/injector": "^1.2"
     },
     "require-dev": {
-        "bamarni/composer-bin-plugin": "^1.8.3",
-        "friendsofphp/php-cs-fixer": "^3.89.2",
-        "phpunit/phpunit": "^10.5.45",
-        "rector/rector": "^2.0.10",
+        "bamarni/composer-bin-plugin": "^1.9.1",
+        "friendsofphp/php-cs-fixer": "^3.95.1",
+        "phpunit/phpunit": "^10.5.63",
+        "rector/rector": "^2.4.2",
         "yiisoft/db-sqlite": "^2.0",
-        "yiisoft/di": "^1.3",
-        "yiisoft/files": "^2.0",
-        "yiisoft/psr-dummy-provider": "^1.0",
-        "yiisoft/test-support": "^3.0.2",
-        "yiisoft/yii-console": "^2.3"
+        "yiisoft/di": "^1.4.1",
+        "yiisoft/files": "^2.1",
+        "yiisoft/psr-dummy-provider": "^1.0.2",
+        "yiisoft/test-support": "^3.2.0",
+        "yiisoft/yii-console": "^2.4.2"
     },
     "autoload": {
         "psr-4": {

--- a/docs/guide/en/usage-standalone.md
+++ b/docs/guide/en/usage-standalone.md
@@ -43,8 +43,12 @@ use Yiisoft\Injector\Injector;
 /** @var ConnectionInterface $database */
 $migrator = new Migrator($database, new NullMigrationInformer());
 $migrationService = new MigrationService($database, new Injector(), $migrator);
-$migrationService->setSourcePaths([dirname(__DIR__, 2), 'migrations']);
+$migrationService->setNewMigrationPath(dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'migrations');
 ```
+
+> [!NOTE]
+> If `sourceNamespaces` and `sourcePaths` are not specified, `newMigrationNamespace` or `newMigrationPath` will be used
+> to find migrations.
 
 Then initialize the command for using without CLI. For example, for applying migrations it will be `UpdateCommand`:
 
@@ -55,7 +59,7 @@ use Yiisoft\Db\Migration\Command\UpdateCommand;
 use Yiisoft\Db\Migration\Runner\UpdateRunner;
 
 $command = new UpdateCommand(new UpdateRunner($migrator), $migrationService, $migrator);
-$command->setHelperSet(new HelperSet(['queestion' => new QuestionHelper()]));
+$command->setHelperSet(new HelperSet(['question' => new QuestionHelper()]));
 ```
 
 And, finally, run the command:

--- a/docs/guide/en/usage-standalone.md
+++ b/docs/guide/en/usage-standalone.md
@@ -47,8 +47,7 @@ $migrationService->setNewMigrationPath(dirname(__DIR__, 2) . DIRECTORY_SEPARATOR
 ```
 
 > [!NOTE]
-> If `sourceNamespaces` and `sourcePaths` are not specified, `newMigrationNamespace` or `newMigrationPath` will be used
-> to find migrations.
+> `sourceNamespaces`, `sourcePaths`, `newMigrationNamespace`, and `newMigrationPath` will be used to find migrations.
 
 Then initialize the command for using without CLI. For example, for applying migrations it will be `UpdateCommand`:
 

--- a/docs/guide/en/usage-with-yii-console.md
+++ b/docs/guide/en/usage-with-yii-console.md
@@ -33,6 +33,10 @@ Add to `config/console/params.php`:
 ...
 ```
 
+> [!NOTE]
+> If `sourceNamespaces` and `sourcePaths` are not specified, `newMigrationNamespace` or `newMigrationPath` will be used
+> to find migrations.
+
 Execute `composer du` in console to rebuild the configuration.
 
 Now we have the `yiisoft/db-migration` package configured and it can be called in the console.

--- a/docs/guide/en/usage-with-yii-console.md
+++ b/docs/guide/en/usage-with-yii-console.md
@@ -34,8 +34,7 @@ Add to `config/console/params.php`:
 ```
 
 > [!NOTE]
-> If `sourceNamespaces` and `sourcePaths` are not specified, `newMigrationNamespace` or `newMigrationPath` will be used
-> to find migrations.
+> `sourceNamespaces`, `sourcePaths`, `newMigrationNamespace`, and `newMigrationPath` will be used to find migrations.
 
 Execute `composer du` in console to rebuild the configuration.
 

--- a/docs/guide/pt-BR/usage-standalone.md
+++ b/docs/guide/pt-BR/usage-standalone.md
@@ -43,8 +43,12 @@ use Yiisoft\Injector\Injector;
 /** @var ConnectionInterface $database */
 $migrator = new Migrator($database, new NullMigrationInformer());
 $migrationService = new MigrationService($database, new Injector(), $migrator);
-$migrationService->setSourcePaths([dirname(__DIR__, 2), 'migrations']);
+$migrationService->setNewMigrationPath(dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'migrations');
 ```
+
+> [!NOTE]
+> Se `sourceNamespaces` e `sourcePaths` não forem especificados, `newMigrationNamespace` ou `newMigrationPath` serão
+> usados para encontrar as migrações.
 
 Em seguida, inicialize o comando para usar sem CLI. Por exemplo, para aplicar migrações será `UpdateCommand`:
 
@@ -55,7 +59,7 @@ use Yiisoft\Db\Migration\Command\UpdateCommand;
 use Yiisoft\Db\Migration\Runner\UpdateRunner;
 
 $command = new UpdateCommand(new UpdateRunner($migrator), $migrationService, $migrator);
-$command->setHelperSet(new HelperSet(['queestion' => new QuestionHelper()]));
+$command->setHelperSet(new HelperSet(['question' => new QuestionHelper()]));
 ```
 
 E, por fim, execute o comando:

--- a/docs/guide/pt-BR/usage-standalone.md
+++ b/docs/guide/pt-BR/usage-standalone.md
@@ -47,8 +47,8 @@ $migrationService->setNewMigrationPath(dirname(__DIR__, 2) . DIRECTORY_SEPARATOR
 ```
 
 > [!NOTE]
-> Se `sourceNamespaces` e `sourcePaths` não forem especificados, `newMigrationNamespace` ou `newMigrationPath` serão
-> usados para encontrar as migrações.
+> `sourceNamespaces`, `sourcePaths`, `newMigrationNamespace` e `newMigrationPath` serão usados para encontrar 
+> as migrações.
 
 Em seguida, inicialize o comando para usar sem CLI. Por exemplo, para aplicar migrações será `UpdateCommand`:
 

--- a/docs/guide/pt-BR/usage-with-yii-console.md
+++ b/docs/guide/pt-BR/usage-with-yii-console.md
@@ -33,6 +33,10 @@ Adicione em `config/console/params.php`:
 ...
 ```
 
+> [!NOTE]
+> Se `sourceNamespaces` e `sourcePaths` não forem especificados, `newMigrationNamespace` ou `newMigrationPath` serão 
+> usados para encontrar as migrações.
+
 Execute `composer du` no console para reconstruir a configuração.
 
 Agora temos o pacote [`yiisoft/db-migration`](https://github.com/yiisoft/db-migration) configurado e ele pode ser chamado no console.

--- a/docs/guide/pt-BR/usage-with-yii-console.md
+++ b/docs/guide/pt-BR/usage-with-yii-console.md
@@ -34,8 +34,8 @@ Adicione em `config/console/params.php`:
 ```
 
 > [!NOTE]
-> Se `sourceNamespaces` e `sourcePaths` não forem especificados, `newMigrationNamespace` ou `newMigrationPath` serão 
-> usados para encontrar as migrações.
+> `sourceNamespaces`, `sourcePaths`, `newMigrationNamespace` e `newMigrationPath` serão usados para encontrar
+> as migrações.
 
 Execute `composer du` no console para reconstruir a configuração.
 

--- a/rector.php
+++ b/rector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Rector\CodeQuality\Rector\Class_\InlineConstructorDefaultToPropertyRector;
 use Rector\Config\RectorConfig;
+use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
 use Rector\Php81\Rector\FuncCall\NullToStrictStringFuncCallArgRector;
 use Rector\Php81\Rector\Property\ReadOnlyPropertyRector;
@@ -21,5 +22,6 @@ return RectorConfig::configure()
         NullToStrictStringFuncCallArgRector::class,
         ReadOnlyPropertyRector::class,
         RemoveExtraParametersRector::class => [__DIR__ . '/src/Service/Generate/PhpRenderer.php'],
+        StringClassNameToClassConstantRector::class => [__DIR__ . '/tests/Common/Service/AbstractMigrationServiceTest.php'],
     ])
     ->withoutParallel();

--- a/src/Service/MigrationService.php
+++ b/src/Service/MigrationService.php
@@ -96,9 +96,13 @@ final class MigrationService
                 }
                 break;
             case 'migrate:up':
-                if (empty($this->sourceNamespaces) && empty($this->sourcePaths)) {
+                if (empty($this->sourceNamespaces)
+                    && empty($this->sourcePaths)
+                    && empty($this->newMigrationNamespace)
+                    && empty($this->newMigrationPath)
+                ) {
                     $this->io?->error(
-                        'At least one of `sourceNamespaces` or `sourcePaths` should be specified.',
+                        'At least one of `sourceNamespaces`, `sourcePaths`, `newMigrationNamespace` or `newMigrationPath` should be specified.',
                     );
 
                     return Command::INVALID;
@@ -124,15 +128,7 @@ final class MigrationService
             $applied[trim($class, '\\')] = true;
         }
 
-        $migrationPaths = [];
-
-        foreach ($this->sourcePaths as $path) {
-            $migrationPaths[] = [$path, ''];
-        }
-
-        foreach ($this->sourceNamespaces as $namespace) {
-            $migrationPaths[] = [$this->getNamespacePath($namespace), $namespace];
-        }
+        $migrationPaths = $this->findSourcePaths();
 
         $migrations = [];
         foreach ($migrationPaths as $item) {
@@ -394,7 +390,7 @@ final class MigrationService
 
         if (!str_contains($class, '\\')) {
             $isIncluded = false;
-            foreach ($this->sourcePaths as $path) {
+            foreach ($this->findSourcePaths() as [$path]) {
                 $file = $path . DIRECTORY_SEPARATOR . $class . '.php';
 
                 if (is_file($file)) {
@@ -414,6 +410,38 @@ final class MigrationService
         $class = '\\' . $class;
 
         return $this->injector->make($class);
+    }
+
+    /**
+     * Returns the migration paths with namespaces if they are specified.
+     *
+     * @return array<array{0: string, 1: string}>
+     */
+    private function findSourcePaths(): array
+    {
+        $paths = [];
+
+        foreach ($this->sourcePaths as $path) {
+            $paths[] = [$path, ''];
+        }
+
+        foreach ($this->sourceNamespaces as $namespace) {
+            $paths[] = [$this->getNamespacePath($namespace), $namespace];
+        }
+
+        if ($paths !== []) {
+            return $paths;
+        }
+
+        if ($this->newMigrationPath !== '') {
+            return [[$this->newMigrationPath, '']];
+        }
+
+        if ($this->newMigrationNamespace !== '') {
+            return [[$this->getNamespacePath($this->newMigrationNamespace), $this->newMigrationNamespace]];
+        }
+
+        return [];
     }
 
     /**

--- a/src/Service/MigrationService.php
+++ b/src/Service/MigrationService.php
@@ -388,7 +388,12 @@ final class MigrationService
 
         if (!str_contains($class, '\\')) {
             $isIncluded = false;
-            foreach ($this->findSourcePaths() as [$path]) {
+
+            $sourcePaths = $this->newMigrationPath !== ''
+                ? [$this->newMigrationPath, ...$this->sourcePaths]
+                : $this->sourcePaths;
+
+            foreach ($sourcePaths as $path) {
                 $file = $path . DIRECTORY_SEPARATOR . $class . '.php';
 
                 if (is_file($file)) {
@@ -420,10 +425,10 @@ final class MigrationService
         $paths = [];
 
         if ($this->newMigrationPath !== '') {
-            $paths = [[$this->newMigrationPath, '']];
+            $paths[] = [$this->newMigrationPath, ''];
         } elseif ($this->newMigrationNamespace !== '') {
             $newMigrationPath = $this->getNamespacePath($this->newMigrationNamespace);
-            $paths = [[$newMigrationPath, $this->newMigrationNamespace]];
+            $paths[] = [$newMigrationPath, $this->newMigrationNamespace];
         }
 
         foreach ($this->sourcePaths as $sourcePaths) {
@@ -431,8 +436,8 @@ final class MigrationService
         }
 
         foreach ($this->sourceNamespaces as $namespace) {
-            $sourcePaths = $this->getNamespacePath($namespace);
-            $paths[] = [$sourcePaths, $namespace];
+            $sourcePath = $this->getNamespacePath($namespace);
+            $paths[] = [$sourcePath, $namespace];
         }
 
         return $paths;

--- a/src/Service/MigrationService.php
+++ b/src/Service/MigrationService.php
@@ -128,12 +128,10 @@ final class MigrationService
             $applied[trim($class, '\\')] = true;
         }
 
+        $migrations = [];
         $migrationPaths = $this->findSourcePaths();
 
-        $migrations = [];
-        foreach ($migrationPaths as $item) {
-            [$sourcePath, $namespace] = $item;
-
+        foreach ($migrationPaths as [$sourcePath, $namespace]) {
             if (!is_dir($sourcePath)) {
                 continue;
             }
@@ -163,8 +161,8 @@ final class MigrationService
             }
             closedir($handle);
         }
-        ksort($migrations);
 
+        ksort($migrations);
         return array_values($migrations);
     }
 
@@ -421,27 +419,23 @@ final class MigrationService
     {
         $paths = [];
 
-        foreach ($this->sourcePaths as $path) {
-            $paths[] = [$path, ''];
+        if ($this->newMigrationPath !== '') {
+            $paths = [[$this->newMigrationPath, '']];
+        } elseif ($this->newMigrationNamespace !== '') {
+            $newMigrationPath = $this->getNamespacePath($this->newMigrationNamespace);
+            $paths = [[$newMigrationPath, $this->newMigrationNamespace]];
+        }
+
+        foreach ($this->sourcePaths as $sourcePaths) {
+            $paths[] = [$sourcePaths, ''];
         }
 
         foreach ($this->sourceNamespaces as $namespace) {
-            $paths[] = [$this->getNamespacePath($namespace), $namespace];
+            $sourcePaths = $this->getNamespacePath($namespace);
+            $paths[] = [$sourcePaths, $namespace];
         }
 
-        if ($paths !== []) {
-            return $paths;
-        }
-
-        if ($this->newMigrationPath !== '') {
-            return [[$this->newMigrationPath, '']];
-        }
-
-        if ($this->newMigrationNamespace !== '') {
-            return [[$this->getNamespacePath($this->newMigrationNamespace), $this->newMigrationNamespace]];
-        }
-
-        return [];
+        return $paths;
     }
 
     /**

--- a/tests/Common/Command/AbstractUpdateCommandTest.php
+++ b/tests/Common/Command/AbstractUpdateCommandTest.php
@@ -274,11 +274,9 @@ abstract class AbstractUpdateCommandTest extends TestCase
         $exitCode = $command->execute([]);
         $output = preg_replace('/(\R|\s)+/', ' ', $command->getDisplay(true));
 
-        $this->assertSame(Command::INVALID, $exitCode);
-        $this->assertStringContainsStringCollapsingSpaces(
-            'At least one of `sourceNamespaces` or `sourcePaths` should be specified.',
-            $output,
-        );
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('No new migrations found.', $output);
+        $this->assertStringContainsString('[OK] Your system is up-to-date.', $output);
     }
 
     public function testWithoutSourceNamespaces(): void
@@ -293,9 +291,49 @@ abstract class AbstractUpdateCommandTest extends TestCase
         $exitCode = $command->execute([]);
         $output = preg_replace('/(\R|\s)+/', ' ', $command->getDisplay(true));
 
+        $this->assertSame(Command::SUCCESS, $exitCode);
+        $this->assertStringContainsString('No new migrations found.', $output);
+        $this->assertStringContainsString('[OK] Your system is up-to-date.', $output);
+    }
+
+    public function testWithoutMigrationPaths()
+    {
+        MigrationHelper::useMigrationsPath($this->container);
+
+        $migration = $this->container->get(MigrationService::class);
+        $migration->setSourcePaths([]);
+        $migration->setNewMigrationPath('');
+
+        $command = $this->createCommand($this->container);
+        $command->setInputs(['yes']);
+
+        $exitCode = $command->execute([]);
+        $output = preg_replace('/(\R|\s)+/', ' ', $command->getDisplay(true));
+
         $this->assertSame(Command::INVALID, $exitCode);
-        $this->assertStringContainsStringCollapsingSpaces(
-            'At least one of `sourceNamespaces` or `sourcePaths` should be specified.',
+        $this->assertStringContainsString(
+            'At least one of `sourceNamespaces`, `sourcePaths`, `newMigrationNamespace` or `newMigrationPath` should be specified.',
+            $output,
+        );
+    }
+
+    public function testWithoutMigrationNamespaces(): void
+    {
+        MigrationHelper::useMigrationsNamespace($this->container);
+
+        $migration = $this->container->get(MigrationService::class);
+        $migration->setSourceNamespaces([]);
+        $migration->setNewMigrationNamespace('');
+
+        $command = $this->createCommand($this->container);
+        $command->setInputs(['yes']);
+
+        $exitCode = $command->execute([]);
+        $output = preg_replace('/(\R|\s)+/', ' ', $command->getDisplay(true));
+
+        $this->assertSame(Command::INVALID, $exitCode);
+        $this->assertStringContainsString(
+            'At least one of `sourceNamespaces`, `sourcePaths`, `newMigrationNamespace` or `newMigrationPath` should be specified.',
             $output,
         );
     }

--- a/tests/Common/Command/AbstractUpdateCommandTest.php
+++ b/tests/Common/Command/AbstractUpdateCommandTest.php
@@ -296,7 +296,7 @@ abstract class AbstractUpdateCommandTest extends TestCase
         $this->assertStringContainsString('[OK] Your system is up-to-date.', $output);
     }
 
-    public function testWithoutMigrationPaths()
+    public function testWithoutMigrationPaths(): void
     {
         MigrationHelper::useMigrationsPath($this->container);
 

--- a/tests/Common/Service/AbstractMigrationServiceTest.php
+++ b/tests/Common/Service/AbstractMigrationServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Migration\Tests\Common\Service;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use ReflectionMethod;
@@ -55,6 +56,171 @@ abstract class AbstractMigrationServiceTest extends TestCase
         $migrations = $service->getNewMigrations();
 
         $this->assertSame([$className], $migrations);
+    }
+
+    public static function getNewMigrationsDataProvider(): array
+    {
+        return [
+            'empty' => [
+                'expected' => [],
+            ],
+            'non exists newMigrationNamespace' => [
+                'expected' => [],
+                'newMigrationNamespace' => 'Yiisoft\Db\Migration\TestsRuntime\NotExists',
+            ],
+            'non exists newMigrationPath' => [
+                'expected' => [],
+                'newMigrationNamespace' => '',
+                'newMigrationPath' => dirname(__DIR__, 2) . '/non-exists-directory',
+            ],
+            'non exists sourceNamespaces' => [
+                'expected' => [],
+                'newMigrationNamespace' => '',
+                'newMigrationPath' => '',
+                'sourceNamespaces' => ['Yiisoft\Db\Migration\TestsRuntime\NotExists'],
+            ],
+            'non exists sourcePaths' => [
+                'expected' => [],
+                'newMigrationNamespace' => '',
+                'newMigrationPath' => '',
+                'sourceNamespaces' => [],
+                'sourcePaths' => [dirname(__DIR__, 2) . '/non-exists-directory'],
+            ],
+            'with newMigrationNamespace' => [
+                'expected' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty'],
+                'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
+            ],
+            'with newMigrationPath' => [
+                'expected' => ['M231108183919Empty'],
+                'newMigrationNamespace' => '',
+                'newMigrationPath' => dirname(__DIR__, 2) . '/Support/MigrationsExtra',
+            ],
+            'with sourceNamespaces with different paths' => [
+                'expected' => [
+                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M231015155500ExecuteSql',
+                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M231017150317EmptyDown',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M250312122400ChangeDbPrefixUp',
+                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M250312122500ChangeDbPrefixDown',
+                ],
+                'newMigrationNamespace' => '',
+                'newMigrationPath' => '',
+                'sourceNamespaces' => [
+                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
+                ],
+            ],
+            'with different sourceNamespaces with the same path' => [
+                'expected' => [
+                    'Yiisoft\Db\Migration\Tests\ForTest\MigrationsExtra\M231108183919Empty',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                ],
+                'newMigrationNamespace' => '',
+                'newMigrationPath' => '',
+                'sourceNamespaces' => [
+                    'Yiisoft\Db\Migration\Tests\ForTest\MigrationsExtra',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
+                ],
+            ],
+            'with sourcePaths with different paths' => [
+                'expected' => [
+                    'M231108183919Empty',
+                    'M231108183919Empty2',
+                ],
+                'newMigrationNamespace' => '',
+                'newMigrationPath' => '',
+                'sourceNamespaces' => [],
+                'sourcePaths' => [
+                    dirname(__DIR__, 2) . '/Support/MigrationsExtra',
+                    dirname(__DIR__, 2) . '/Support/MigrationsExtra2',
+                ],
+            ],
+            'with sourceNamespaces and sourcePaths with the same path' => [
+                'expected' => [
+                    'M231108183919Empty',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                ],
+                'newMigrationNamespace' => '',
+                'newMigrationPath' => '',
+                'sourceNamespaces' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra'],
+                'sourcePaths' => [dirname(__DIR__, 2) . '/Support/MigrationsExtra'],
+            ],
+            'with sourceNamespaces and sourcePaths with different paths' => [
+                'expected' => [
+                    'M231108183919Empty2',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                ],
+                'newMigrationNamespace' => '',
+                'newMigrationPath' => '',
+                'sourceNamespaces' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra'],
+                'sourcePaths' => [dirname(__DIR__, 2) . '/Support/MigrationsExtra2'],
+            ],
+            'with newMigrationNamespace and sourceNamespaces with the same path' => [
+                'expected' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty'],
+                'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
+                'newMigrationPath' => '',
+                'sourceNamespaces' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra'],
+            ],
+            'with newMigrationPath and sourcePaths with the same path' => [
+                'expected' => ['M231108183919Empty'],
+                'newMigrationNamespace' => '',
+                'newMigrationPath' => dirname(__DIR__, 2) . '/Support/MigrationsExtra',
+                'sourceNamespaces' => [],
+                'sourcePaths' => [dirname(__DIR__, 2) . '/Support/MigrationsExtra'],
+            ],
+            'with newMigrationNamespace and sourcePaths with the same path' => [
+                'expected' => [
+                    'M231108183919Empty',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                ],
+                'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
+                'newMigrationPath' => '',
+                'sourceNamespaces' => [],
+                'sourcePaths' => [dirname(__DIR__, 2) . '/Support/MigrationsExtra'],
+            ],
+            'with newMigrationNamespace and sourceNamespaces with different paths' => [
+                'expected' => [
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M231015155500ExecuteSql',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M231017150317EmptyDown',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122400ChangeDbPrefixUp',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122500ChangeDbPrefixDown',
+                ],
+                'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
+                'newMigrationPath' => '',
+                'sourceNamespaces' => ['Yiisoft\Db\Migration\Tests\Support\Migrations'],
+            ],
+            'with newMigrationPath and sourceNamespaces with different paths' => [
+                'expected' => [
+                    'M231108183919Empty2',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                ],
+                'newMigrationNamespace' => '',
+                'newMigrationPath' => dirname(__DIR__, 2) . '/Support/MigrationsExtra2',
+                'sourceNamespaces' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra'],
+            ],
+        ];
+    }
+
+    #[DataProvider('getNewMigrationsDataProvider')]
+    public function testGetNewMigrations(
+        array $expected,
+        string $newMigrationNamespace = '',
+        string $newMigrationPath = '',
+        array $sourceNamespaces = [],
+        array $sourcePaths = [],
+    ): void {
+        MigrationHelper::useMigrationsNamespace($this->container);
+
+        $service = $this->container->get(MigrationService::class);
+        $service->setNewMigrationNamespace($newMigrationNamespace);
+        $service->setNewMigrationPath($newMigrationPath);
+        $service->setSourceNamespaces($sourceNamespaces);
+        $service->setSourcePaths($sourcePaths);
+
+        $migrations = $service->getNewMigrations();
+
+        $this->assertSame($expected, $migrations);
     }
 
     public function testGetNamespacesFromPathForNoHavingNamespacePath(): void

--- a/tests/Common/Service/AbstractMigrationServiceTest.php
+++ b/tests/Common/Service/AbstractMigrationServiceTest.php
@@ -99,7 +99,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
                 'expected' => [
                     'Yiisoft\Db\Migration\Tests\Support\Migrations\M231015155500ExecuteSql',
                     'Yiisoft\Db\Migration\Tests\Support\Migrations\M231017150317EmptyDown',
-                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
                     'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122400ChangeDbPrefixUp',
                     'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122500ChangeDbPrefixDown',
                 ],

--- a/tests/Common/Service/AbstractMigrationServiceTest.php
+++ b/tests/Common/Service/AbstractMigrationServiceTest.php
@@ -87,7 +87,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
                 'sourcePaths' => [dirname(__DIR__, 2) . '/non-exists-directory'],
             ],
             'with newMigrationNamespace' => [
-                'expected' => [\Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class],
+                'expected' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty'],
                 'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
             ],
             'with newMigrationPath' => [
@@ -97,23 +97,23 @@ abstract class AbstractMigrationServiceTest extends TestCase
             ],
             'with sourceNamespaces with different paths' => [
                 'expected' => [
-                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M231015155500ExecuteSql',
-                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M231017150317EmptyDown',
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
-                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M250312122400ChangeDbPrefixUp',
-                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M250312122500ChangeDbPrefixDown',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M231015155500ExecuteSql',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M231017150317EmptyDown',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122400ChangeDbPrefixUp',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122500ChangeDbPrefixDown',
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => '',
                 'sourceNamespaces' => [
-                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations',
                     'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
                 ],
             ],
             'with different sourceNamespaces with the same path' => [
                 'expected' => [
                     'Yiisoft\Db\Migration\Tests\ForTest\MigrationsExtra\M231108183919Empty',
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => '',
@@ -138,7 +138,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with sourceNamespaces and sourcePaths with the same path' => [
                 'expected' => [
                     'M231108183919Empty',
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => '',
@@ -148,7 +148,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with sourceNamespaces and sourcePaths with different paths' => [
                 'expected' => [
                     'M231108183919Empty2',
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => '',
@@ -156,7 +156,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
                 'sourcePaths' => [dirname(__DIR__, 2) . '/Support/MigrationsExtra2'],
             ],
             'with newMigrationNamespace and sourceNamespaces with the same path' => [
-                'expected' => [\Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class],
+                'expected' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty'],
                 'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
                 'newMigrationPath' => '',
                 'sourceNamespaces' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra'],
@@ -171,7 +171,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with newMigrationNamespace and sourcePaths with the same path' => [
                 'expected' => [
                     'M231108183919Empty',
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
                 ],
                 'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
                 'newMigrationPath' => '',
@@ -180,11 +180,11 @@ abstract class AbstractMigrationServiceTest extends TestCase
             ],
             'with newMigrationNamespace and sourceNamespaces with different paths' => [
                 'expected' => [
-                    \Yiisoft\Db\Migration\Tests\Support\Migrations\M231015155500ExecuteSql::class,
-                    \Yiisoft\Db\Migration\Tests\Support\Migrations\M231017150317EmptyDown::class,
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
-                    \Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122400ChangeDbPrefixUp::class,
-                    \Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122500ChangeDbPrefixDown::class,
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M231015155500ExecuteSql',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M231017150317EmptyDown',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122400ChangeDbPrefixUp',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122500ChangeDbPrefixDown',
                 ],
                 'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
                 'newMigrationPath' => '',
@@ -193,7 +193,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with newMigrationPath and sourceNamespaces with different paths' => [
                 'expected' => [
                     'M231108183919Empty2',
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => dirname(__DIR__, 2) . '/Support/MigrationsExtra2',

--- a/tests/Common/Service/AbstractMigrationServiceTest.php
+++ b/tests/Common/Service/AbstractMigrationServiceTest.php
@@ -87,7 +87,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
                 'sourcePaths' => [dirname(__DIR__, 2) . '/non-exists-directory'],
             ],
             'with newMigrationNamespace' => [
-                'expected' => [\Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class],
+                'expected' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty'],
                 'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
             ],
             'with newMigrationPath' => [
@@ -97,23 +97,23 @@ abstract class AbstractMigrationServiceTest extends TestCase
             ],
             'with sourceNamespaces with different paths' => [
                 'expected' => [
-                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M231015155500ExecuteSql',
-                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M231017150317EmptyDown',
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
-                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M250312122400ChangeDbPrefixUp',
-                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M250312122500ChangeDbPrefixDown',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M231015155500ExecuteSql',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M231017150317EmptyDown',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122400ChangeDbPrefixUp',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122500ChangeDbPrefixDown',
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => '',
                 'sourceNamespaces' => [
-                    'Yiisoft\Db\Migration\Tests\ForTest\Migrations',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations',
                     'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
                 ],
             ],
             'with different sourceNamespaces with the same path' => [
                 'expected' => [
                     'Yiisoft\Db\Migration\Tests\ForTest\MigrationsExtra\M231108183919Empty',
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => '',
@@ -138,7 +138,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with sourceNamespaces and sourcePaths with the same path' => [
                 'expected' => [
                     'M231108183919Empty',
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => '',
@@ -148,7 +148,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with sourceNamespaces and sourcePaths with different paths' => [
                 'expected' => [
                     'M231108183919Empty2',
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => '',
@@ -156,7 +156,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
                 'sourcePaths' => [dirname(__DIR__, 2) . '/Support/MigrationsExtra2'],
             ],
             'with newMigrationNamespace and sourceNamespaces with the same path' => [
-                'expected' => [\Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class],
+                'expected' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty'],
                 'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
                 'newMigrationPath' => '',
                 'sourceNamespaces' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra'],
@@ -171,7 +171,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with newMigrationNamespace and sourcePaths with the same path' => [
                 'expected' => [
                     'M231108183919Empty',
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
                 ],
                 'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
                 'newMigrationPath' => '',
@@ -180,11 +180,11 @@ abstract class AbstractMigrationServiceTest extends TestCase
             ],
             'with newMigrationNamespace and sourceNamespaces with different paths' => [
                 'expected' => [
-                    \Yiisoft\Db\Migration\Tests\Support\Migrations\M231015155500ExecuteSql::class,
-                    \Yiisoft\Db\Migration\Tests\Support\Migrations\M231017150317EmptyDown::class,
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
-                    \Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122400ChangeDbPrefixUp::class,
-                    \Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122500ChangeDbPrefixDown::class,
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M231015155500ExecuteSql',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M231017150317EmptyDown',
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122400ChangeDbPrefixUp',
+                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122500ChangeDbPrefixDown',
                 ],
                 'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
                 'newMigrationPath' => '',
@@ -193,7 +193,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with newMigrationPath and sourceNamespaces with different paths' => [
                 'expected' => [
                     'M231108183919Empty2',
-                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
+                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => dirname(__DIR__, 2) . '/Support/MigrationsExtra2',

--- a/tests/Common/Service/AbstractMigrationServiceTest.php
+++ b/tests/Common/Service/AbstractMigrationServiceTest.php
@@ -87,7 +87,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
                 'sourcePaths' => [dirname(__DIR__, 2) . '/non-exists-directory'],
             ],
             'with newMigrationNamespace' => [
-                'expected' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty'],
+                'expected' => [\Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class],
                 'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
             ],
             'with newMigrationPath' => [
@@ -99,7 +99,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
                 'expected' => [
                     'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M231015155500ExecuteSql',
                     'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M231017150317EmptyDown',
-                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
                     'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M250312122400ChangeDbPrefixUp',
                     'Yiisoft\Db\Migration\Tests\ForTest\Migrations\M250312122500ChangeDbPrefixDown',
                 ],
@@ -113,7 +113,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with different sourceNamespaces with the same path' => [
                 'expected' => [
                     'Yiisoft\Db\Migration\Tests\ForTest\MigrationsExtra\M231108183919Empty',
-                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => '',
@@ -138,7 +138,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with sourceNamespaces and sourcePaths with the same path' => [
                 'expected' => [
                     'M231108183919Empty',
-                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => '',
@@ -148,7 +148,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with sourceNamespaces and sourcePaths with different paths' => [
                 'expected' => [
                     'M231108183919Empty2',
-                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => '',
@@ -156,7 +156,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
                 'sourcePaths' => [dirname(__DIR__, 2) . '/Support/MigrationsExtra2'],
             ],
             'with newMigrationNamespace and sourceNamespaces with the same path' => [
-                'expected' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty'],
+                'expected' => [\Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class],
                 'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
                 'newMigrationPath' => '',
                 'sourceNamespaces' => ['Yiisoft\Db\Migration\Tests\Support\MigrationsExtra'],
@@ -171,7 +171,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with newMigrationNamespace and sourcePaths with the same path' => [
                 'expected' => [
                     'M231108183919Empty',
-                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
                 ],
                 'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
                 'newMigrationPath' => '',
@@ -180,11 +180,11 @@ abstract class AbstractMigrationServiceTest extends TestCase
             ],
             'with newMigrationNamespace and sourceNamespaces with different paths' => [
                 'expected' => [
-                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M231015155500ExecuteSql',
-                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M231017150317EmptyDown',
-                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
-                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122400ChangeDbPrefixUp',
-                    'Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122500ChangeDbPrefixDown',
+                    \Yiisoft\Db\Migration\Tests\Support\Migrations\M231015155500ExecuteSql::class,
+                    \Yiisoft\Db\Migration\Tests\Support\Migrations\M231017150317EmptyDown::class,
+                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
+                    \Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122400ChangeDbPrefixUp::class,
+                    \Yiisoft\Db\Migration\Tests\Support\Migrations\M250312122500ChangeDbPrefixDown::class,
                 ],
                 'newMigrationNamespace' => 'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra',
                 'newMigrationPath' => '',
@@ -193,7 +193,7 @@ abstract class AbstractMigrationServiceTest extends TestCase
             'with newMigrationPath and sourceNamespaces with different paths' => [
                 'expected' => [
                     'M231108183919Empty2',
-                    'Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty',
+                    \Yiisoft\Db\Migration\Tests\Support\MigrationsExtra\M231108183919Empty::class,
                 ],
                 'newMigrationNamespace' => '',
                 'newMigrationPath' => dirname(__DIR__, 2) . '/Support/MigrationsExtra2',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
