### PR TITLE
Add `MigrationBuilder::insertBatch()` method, deprecate `batchInsert()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.2 under development
 
+- New #332: Add `MigrationBuilder::insertBatch()` method, deprecate `batchInsert()` (@vjik)
 - Enh #317: Explicitly import classes, functions, and constants in "use" section (@mspirkov)
 - Enh #318: Remove unnecessary files from Composer package (@mspirkov)
 - Enh #319: Remove confirmation prompt from `migrate:create` command as creating a migration is non-destructive (@samdark)

--- a/src/MigrationBuilder.php
+++ b/src/MigrationBuilder.php
@@ -107,14 +107,38 @@ final class MigrationBuilder
      * The method will properly escape the column names and bind the values to be inserted.
      *
      * @param string $table The table that new rows will be inserted into.
-     * @param string[] $columns The column names.
-     * @param iterable $rows The rows to be batch inserted into the table
+     * @param iterable $rows The rows to be batch inserted into the table.
+     * @param array $columns The column names.
      *
      * @psalm-param iterable<iterable<array-key, mixed>> $rows
      *
      * @throws Exception
      * @throws InvalidConfigException
      * @throws NotSupportedException
+     */
+    public function insertBatch(string $table, iterable $rows, array $columns = []): void
+    {
+        $time = $this->beginCommand("Insert into $table");
+        $this->db->createCommand()->insertBatch($table, $rows, $columns)->execute();
+        $this->endCommand($time);
+    }
+
+    /**
+     * Creates and executes a batch INSERT SQL statement.
+     *
+     * The method will properly escape the column names and bind the values to be inserted.
+     *
+     * @param string $table The table that new rows will be inserted into.
+     * @param string[] $columns The column names.
+     * @param iterable $rows The rows to be batch inserted into the table.
+     *
+     * @psalm-param iterable<iterable<array-key, mixed>> $rows
+     *
+     * @throws Exception
+     * @throws InvalidConfigException
+     * @throws NotSupportedException
+     *
+     * @deprecated Use {@see insertBatch()} instead.
      */
     public function batchInsert(string $table, array $columns, iterable $rows): void
     {

--- a/src/MigrationBuilder.php
+++ b/src/MigrationBuilder.php
@@ -108,7 +108,7 @@ final class MigrationBuilder
      *
      * @param string $table The table that new rows will be inserted into.
      * @param iterable $rows The rows to be batch inserted into the table.
-     * @param array $columns The column names.
+     * @param string[] $columns The column names.
      *
      * @psalm-param iterable<iterable<array-key, mixed>> $rows
      *

--- a/tests/Common/AbstractMigrationBuilderTest.php
+++ b/tests/Common/AbstractMigrationBuilderTest.php
@@ -59,6 +59,34 @@ abstract class AbstractMigrationBuilderTest extends TestCase
         $this->builder->dropTable('test');
     }
 
+    public function testInsertBatch(): void
+    {
+        $this->builder->createTable('test', ['id' => ColumnBuilder::integer()]);
+        $this->builder->insertBatch('test', [['id' => 1], ['id' => 2]]);
+
+        $this->assertEquals(
+            '2',
+            $this->db->createCommand('SELECT count(*) FROM {{test}} WHERE [[id]] IN (1, 2)')->queryScalar(),
+        );
+        $this->assertInformerOutputContains('    > Insert into test ... Done in ');
+
+        $this->builder->dropTable('test');
+    }
+
+    public function testInsertBatchWithColumns(): void
+    {
+        $this->builder->createTable('test', ['id' => ColumnBuilder::integer()]);
+        $this->builder->insertBatch('test', [[1], [2]], ['id']);
+
+        $this->assertEquals(
+            '2',
+            $this->db->createCommand('SELECT count(*) FROM {{test}} WHERE [[id]] IN (1, 2)')->queryScalar(),
+        );
+        $this->assertInformerOutputContains('    > Insert into test ... Done in ');
+
+        $this->builder->dropTable('test');
+    }
+
     public function testBatchInsert(): void
     {
         $this->builder->createTable('test', ['id' => ColumnBuilder::integer()]);


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
Fix #332 
